### PR TITLE
Fixed DebugBackend::RegisterScript and DebugBackend::GetScriptIndex not declared as retuning signed int

### DIFF
--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -469,7 +469,7 @@ int DebugBackend::PostLoadScript(unsigned long api, int result, lua_State* L, co
 
 }
 
-unsigned int DebugBackend::RegisterScript(lua_State* L, const char* source, size_t size, const char* name, bool unavailable)
+int DebugBackend::RegisterScript(lua_State* L, const char* source, size_t size, const char* name, bool unavailable)
 {
 
     CriticalSectionLock lock(m_criticalSection);
@@ -704,7 +704,7 @@ void DebugBackend::HookCallback(unsigned long api, lua_State* L, lua_Debug* ar)
         // Fill in the rest of the structure.
         lua_getinfo_dll(api, L, "Sl", ar);
 
-        unsigned int scriptIndex = GetScriptIndex(ar->source);
+        int scriptIndex = GetScriptIndex(ar->source);
 
         bool stop = false;
 
@@ -819,7 +819,7 @@ void DebugBackend::HookCallback(unsigned long api, lua_State* L, lua_Debug* ar)
 
 }
 
-unsigned int DebugBackend::GetScriptIndex(const char* name) const
+int DebugBackend::GetScriptIndex(const char* name) const
 {
 
     NameToScriptMap::const_iterator iterator = m_nameToScript.find(name);
@@ -2015,7 +2015,7 @@ TiXmlNode* DebugBackend::GetValueAsText(unsigned long api, lua_State* L, int n, 
         lua_Debug ar;
         lua_getinfo_dll(api, L, ">Sn", &ar);
 
-        unsigned int scriptIndex = GetScriptIndex(ar.source);
+        int scriptIndex = GetScriptIndex(ar.source);
 
         node = new TiXmlElement("function");
         node->LinkEndChild(WriteXmlNode("script", scriptIndex));

--- a/src/LuaInject/DebugBackend.h
+++ b/src/LuaInject/DebugBackend.h
@@ -96,7 +96,7 @@ public:
      * was not available for the script. This should be set if the script was encountered
      * through a call other than the load function.
      */
-    unsigned int RegisterScript(lua_State* L, const char* source, size_t size, const char* name, bool unavailable);
+    int RegisterScript(lua_State* L, const char* source, size_t size, const char* name, bool unavailable);
 
     /**
      * Steps execution of a "broken" script by one line. If the current line
@@ -161,7 +161,7 @@ public:
      * name. The name is the same name that was supplied when the script was
      * loaded.
      */
-    unsigned int GetScriptIndex(const char* name) const;
+    int GetScriptIndex(const char* name) const;
 
     /**
      * Returns the class name associated with the metatable index. This makes


### PR DESCRIPTION
Fixed DebugBackend::RegisterScript and DebugBackend::GetScriptIndex wrongly declared as returning an unsigned int when in fact they can return -1 and fix this wrong assumption in other places
