### PR TITLE
Debugger Fastmode

### DIFF
--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -301,7 +301,7 @@ DebugBackend::VirtualMachine* DebugBackend::AttachState(unsigned long api, lua_S
     RegisterDebugLibrary(api, L);
 
     // Start debugging on this VM.
-    SetHookEnabled(api, L, true);
+    SetHookMode(api, L, HookMode_Full);
 
     // This state may be a thread which will be garbage collected, so we need to register
     // to recieve notification when it is destroyed.
@@ -871,7 +871,7 @@ void DebugBackend::CommandThreadProc()
 
             for (unsigned int i = 0; i < m_vms.size(); ++i)
             {
-                SetHookEnabled(m_vms[i]->api, m_vms[i]->L, false);
+                SetHookMode(m_vms[i]->api, m_vms[i]->L, HookMode_None);
             }
 
             // Signal that we're detached.
@@ -1709,7 +1709,7 @@ bool DebugBackend::Evaluate(unsigned long api, lua_State* L, const std::string& 
     int localTable   = envTable - 2;
 
     // Disable the debugger hook so that we don't try to debug the expression.
-    SetHookEnabled(api, L, false);
+    SetHookMode(api, L, HookMode_None);
     EnableIntercepts(false);
     
     int stackTop = lua_gettop_dll(api, L);    
@@ -1826,7 +1826,7 @@ bool DebugBackend::Evaluate(unsigned long api, lua_State* L, const std::string& 
 
     // Reenable the debugger hook
     EnableIntercepts(true);
-    SetHookEnabled(api, L, true);
+    SetHookMode(api, L, HookMode_Full);
 
     int t2 = lua_gettop_dll(api, L);
     assert(t1 == t2);

--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -884,6 +884,12 @@ void DebugBackend::HookCallback(unsigned long api, lua_State* L, lua_Debug* ar)
 
 void DebugBackend::UpdateHookMode(unsigned long api, lua_State* L, lua_Debug* hookEvent)
 {
+    //Only update the hook mode for call or return hook events 
+    if(hookEvent->event == LUA_HOOKLINE)
+    {
+        return;
+    } 
+    
     VirtualMachine* vm = GetVm(L);
     HookMode mode = HookMode_CallsOnly;
 

--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -955,16 +955,18 @@ bool DebugBackend::StackHasBreakpoint(unsigned long api, lua_State* L){
           //ignore c functions
           continue;
         }
-        
+
         vm->lastFunctions = functionInfo.source;
 
         int scriptIndex = GetScriptIndex(vm->lastFunctions);
         
-        if(scriptIndex != -1 && m_scripts[scriptIndex]->HasBreakpointsActive())
+        Script* script = scriptIndex != -1 ? m_scripts[scriptIndex] : NULL;
+
+        if(script != NULL && (script->HasBreakPointInRange(functionInfo.linedefined, functionInfo.lastlinedefined) ||
+           //Check if the function is the top level chunk of a source file                       
+           (script->HasBreakpointsActive() && functionInfo.linedefined == 0 && functionInfo.lastlinedefined == 0)))
         {
-          return m_scripts[scriptIndex]->HasBreakPointInRange(functionInfo.linedefined, functionInfo.lastlinedefined) ||
-                 //Check if the function is the top level chunk of a source file                       
-                 (functionInfo.linedefined == 0 && functionInfo.lastlinedefined == 0);
+            return true;
         }
 
     }

--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -327,7 +327,7 @@ DebugBackend::VirtualMachine* DebugBackend::AttachState(unsigned long api, lua_S
     vm->api                 = api;
     vm->stackTop            = 0;
     vm->luaJitWorkAround    = false;
-    vm->breakpointInStack = false;
+    vm->breakpointInStack   = true;// Force the stack tobe checked when the first script is entered
     
     m_vms.push_back(vm);
     m_stateToVm.insert(std::make_pair(L, vm));
@@ -908,14 +908,18 @@ void DebugBackend::UpdateHookMode(unsigned long api, lua_State* L, lua_Debug* ho
             scriptIndex = GetScriptIndex(vm->lastFunctions);
         }
         
-        if(scriptIndex != -1 && m_scripts[scriptIndex]->HasBreakPointInRange(hookEvent->linedefined, hookEvent->lastlinedefined))
+        Script* script = scriptIndex != -1 ? m_scripts[scriptIndex] : NULL;
+
+        if(script != NULL && (script->HasBreakPointInRange(hookEvent->linedefined, hookEvent->lastlinedefined) ||
+           //Check if the function is the top level chunk of a script because they always have there lastlinedefined set to 0                  
+           (script->HasBreakpointsActive() && hookEvent->linedefined == 0 && hookEvent->lastlinedefined == 0)))
         {
             mode = HookMode_Full;
             vm->breakpointInStack = true;
         }
     }
 
-    //keep the hook in Full mode while theres a function in the stack somewhere that has a breakpoint in it
+    //Keep the hook in Full mode while theres a function in the stack somewhere that has a breakpoint in it
     if(mode != HookMode_Full && vm->breakpointInStack)
     {
       if(StackHasBreakpoint(api, L))

--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -68,11 +68,54 @@ const char* MemoryReader(lua_State* L, void* data, size_t* size)
 
 bool DebugBackend::Script::GetHasBreakPoint(unsigned int line) const
 {
-    if (line < breakpoints.size())
+    
+    for (size_t i = 0; i < breakpoints.size(); i++)
     {
-        return breakpoints[line];
+      if(breakpoints[i] == line){
+        return true;
+      }
     }
+    
     return false;
+}
+
+bool DebugBackend::Script::HasBreakPointInRange(unsigned int start, unsigned int end) const
+{
+    
+    for (size_t i = 0; i < breakpoints.size(); i++)
+    {
+      if(breakpoints[i] >= start && breakpoints[i] < end)
+      {
+        return true;
+      }
+    }
+    
+    return false;
+}
+
+bool DebugBackend::Script::ToggleBreakpoint(unsigned int line)
+{
+
+    std::vector<unsigned int>::iterator result = std::find(breakpoints.begin(), breakpoints.end(), line);
+
+    if(result == breakpoints.end())
+    {
+      breakpoints.push_back(line);
+      return true;
+    }else{
+      breakpoints.erase(result);
+      return false;
+    }
+}
+
+void DebugBackend::Script::ClearBreakpoints()
+{
+    breakpoints.resize(0);
+}
+
+bool DebugBackend::Script::HasBreakpointsActive()
+{
+  return breakpoints.size() != 0;
 }
 
 DebugBackend& DebugBackend::Get()
@@ -1074,20 +1117,15 @@ void DebugBackend::ToggleBreakpoint(lua_State* L, unsigned int scriptIndex, unsi
 
     if (foundValidLine)
     {
-
-        if (script->breakpoints.size() < line + 1)
-        {
-            script->breakpoints.resize(line + 1, false);
-        }
-
-        script->breakpoints[line] = !script->breakpoints[line];
+        
+        bool breakpointSet = script->ToggleBreakpoint(line);
 
         // Send back the event telling the frontend that we set/unset the breakpoint.
         m_eventChannel.WriteUInt32(EventId_SetBreakpoint);    
         m_eventChannel.WriteUInt32(reinterpret_cast<int>(L));  
         m_eventChannel.WriteUInt32(scriptIndex);
         m_eventChannel.WriteUInt32(line);
-        m_eventChannel.WriteUInt32(script->breakpoints[line]);
+        m_eventChannel.WriteUInt32(breakpointSet);
         m_eventChannel.Flush();
     
     }

--- a/src/LuaInject/DebugBackend.h
+++ b/src/LuaInject/DebugBackend.h
@@ -98,6 +98,8 @@ public:
      */
     unsigned int RegisterScript(lua_State* L, const char* source, size_t size, const char* name, bool unavailable);
 
+    int RegisterScript(lua_State* L, lua_Debug* ar);
+
     /**
      * Steps execution of a "broken" script by one line. If the current line
      * is a function call, this will step into the function call.
@@ -161,7 +163,9 @@ public:
      * name. The name is the same name that was supplied when the script was
      * loaded.
      */
-    unsigned int GetScriptIndex(const char* name) const;
+    unsigned int GetScriptIndex(const std::string& name) const;
+
+    bool StackHasBreakpoint(unsigned long api, lua_State* L);
 
     /**
      * Returns the class name associated with the metatable index. This makes
@@ -391,6 +395,8 @@ private:
         std::string     name;
         unsigned int    stackTop;
         bool            luaJitWorkAround;
+        bool            breakpointInStack;
+        std::string     lastFunctions;
     };
 
     struct StackEntry
@@ -516,6 +522,8 @@ private:
      * Logs information about a hook callback event. This is used for debugging.
      */
     void LogHookEvent(unsigned long api, lua_State* L, lua_Debug* ar);
+
+    void UpdateHookMode(unsigned long api, lua_State* L, lua_Debug* hookEvent);
 
     /**
      * Calls the named meta-method for the specified value. If the value does

--- a/src/LuaInject/DebugBackend.h
+++ b/src/LuaInject/DebugBackend.h
@@ -225,10 +225,18 @@ private:
          */
         bool GetHasBreakPoint(unsigned int line) const;
         
+        bool HasBreakPointInRange(unsigned int start, unsigned int end) const;
+
+        bool ToggleBreakpoint(unsigned int line);
+
+        bool HasBreakpointsActive();
+
+        void ClearBreakpoints();
+
         std::string                 name;
         std::string                 source;
         std::string                 title;
-        std::vector<bool>           breakpoints;    // True for the indices of lines that have breakpoints.
+        std::vector<unsigned int>   breakpoints;    // True for the indices of lines that have breakpoints.
         std::vector<unsigned int>   validLines;     // Lines that can have breakpoints on them.
 
     };

--- a/src/LuaInject/LuaDll.h
+++ b/src/LuaInject/LuaDll.h
@@ -166,11 +166,23 @@ bool GetAreInterceptsEnabled();
  */
 bool GetIsStdCall(unsigned long api);
 
+enum HookMode
+{
+    HookMode_None,
+    HookMode_CallsOnly,
+    HookMode_CallsAndReturns,
+    HookMode_Full,
+};
 /**
- * Enables or disables the debug hook callback for the specified state. The state
- * can only be debugged when the hook is installed.
+ * Sets the debug hook mode for the specified state. The state
+ * can only be debugged when the hook is higher than HookMode_None.
  */
-void SetHookEnabled(unsigned long api, lua_State* L, bool hookEnabled);
+void SetHookMode(unsigned long api, lua_State* L, HookMode mode);
+
+/**
+ * Returns the current hook mode for the specified state.
+ */
+HookMode GetHookMode(unsigned long api, lua_State* L);
 
 /**
  * Creates a new function that can be used with the specified API. The new function


### PR DESCRIPTION
This pull request is only for the fast mode for when breakpoints are set I don't know if you want the fast mode for no breakpoints also included in this pull request. The code almost ready to be merged but it would be great to have you input on anything you think needs changing.

This fast mode works by only using the Lua call hook when there is no Lua functions in the call stack with breakpoints set. The call stack checking and line,return hooks are only turned on when entering a function with breakpoints set and will automatically turn off when there are no functions with breakpoints left in the stack. The hook mode switching is also paused when the debugger is stepping.

The hook mode could maybe downgraded to just call and returns when the current function with breakpoints calls another function.
