### PR TITLE
Process output deadlock fix & External tool improvements

### DIFF
--- a/src/Frontend/ExternalTool.cpp
+++ b/src/Frontend/ExternalTool.cpp
@@ -49,6 +49,16 @@ const wxString& ExternalTool::GetCommand() const
     return m_command;
 }
 
+void ExternalTool::SetInitialDirectory(const wxString& initialDirectory)
+{
+    m_initialDirectory = initialDirectory;
+}
+
+const wxString& ExternalTool::GetInitialDirectory() const
+{
+    return m_initialDirectory;
+}
+
 void ExternalTool::SetArguments(const wxString& arguments)
 {
     m_arguments = arguments;
@@ -86,12 +96,23 @@ wxProcess* ExternalTool::Run(const MainFrame* mainFrame) const
     // automatic one called from wxProcess::Open.
     wxLogNull logNo;
 
-    wxString commandLine;
-    commandLine = m_command + " " + m_arguments;
-
-    mainFrame->SubstituteVariableArguments(commandLine);
+    wxString commandLine      = m_command + " " + m_arguments;
+    wxString initialDirectory = m_initialDirectory;
+    mainFrame->SubstituteVariableArguments(commandLine     );
+    mainFrame->SubstituteVariableArguments(initialDirectory);
+    
+    wxString workDirOriginal;
+    if (!initialDirectory.IsEmpty())
+    {
+        workDirOriginal = wxGetCwd();
+        wxSetWorkingDirectory(initialDirectory);
+    }
 
     wxProcess* process = wxProcess::Open(commandLine);
+
+    if (!initialDirectory.IsEmpty())
+        wxSetWorkingDirectory(workDirOriginal);
+
     return process;
 
 }

--- a/src/Frontend/ExternalTool.h
+++ b/src/Frontend/ExternalTool.h
@@ -71,6 +71,16 @@ public:
     const wxString& GetCommand() const;
 
     /**
+     * Sets the initial working directory for the tool.
+     */
+    void SetInitialDirectory(const wxString& initialDirectory);
+
+    /**
+     * Returns the initial working directory for the tool.
+     */
+    const wxString& GetInitialDirectory() const;
+
+    /**
      * Sets the arguments that will be supplied to the application when it's
      * executed. This can contain embedded environment variables (i.e $(...)).
      */

--- a/src/Frontend/ExternalToolsDialog.cpp
+++ b/src/Frontend/ExternalToolsDialog.cpp
@@ -30,6 +30,7 @@ BEGIN_EVENT_TABLE(ExternalToolsDialog, wxDialog)
     EVT_TEXT(ID_TitleTextBox,               OnTitleTextBoxChanged)
     EVT_TEXT(ID_CommandTextBox,             OnCommandTextBoxChanged)
     EVT_TEXT(ID_ArgumentsTextBox,           OnArgumentsTextBoxChanged)
+    EVT_TEXT(ID_InitialDirectoryTextBox,    OnInitialDirectoryTextBoxChanged)
     EVT_BUTTON(wxID_OK,                     OnOk)
     EVT_BUTTON(ID_ApplyButton,              OnApply)
     EVT_BUTTON(ID_AddButton,                OnAdd)
@@ -38,10 +39,15 @@ BEGIN_EVENT_TABLE(ExternalToolsDialog, wxDialog)
     EVT_BUTTON(ID_MoveDownButton,           OnMoveDown)
     EVT_BUTTON(ID_CommandBrowseButton,      OnCommandBrowse)
     EVT_BUTTON(ID_ArgumentsBrowseButton,    OnArgumentsBrowse)
-    EVT_MENU(ID_ItemPath,                   OnItemPath)
-    EVT_MENU(ID_ItemDirectory,              OnItemDirectory)
-    EVT_MENU(ID_ItemFileName,               OnItemFileName)
-    EVT_MENU(ID_ItemExtension,              OnItemExtension)
+    EVT_BUTTON(ID_InitialDirBrowseButton,   OnInitialDirectoryBrowse)
+    EVT_MENU(ID_ArgumentsItemPath,             OnArgumentsItemPath)
+    EVT_MENU(ID_ArgumentsItemDirectory,        OnArgumentsItemDirectory)
+    EVT_MENU(ID_ArgumentsItemFileName,         OnArgumentsItemFileName)
+    EVT_MENU(ID_ArgumentsItemExtension,        OnArgumentsItemExtension)
+    EVT_MENU(ID_InitialDirectoryItemPath,      OnInitialDirectoryItemPath)
+    EVT_MENU(ID_InitialDirectoryItemDirectory, OnInitialDirectoryItemDirectory)
+    EVT_MENU(ID_InitialDirectoryItemFileName,  OnInitialDirectoryItemFileName)
+    EVT_MENU(ID_InitialDirectoryItemExtension, OnInitialDirectoryItemExtension)
     EVT_CHOICE(ID_EventHook,                OnEventHook)
     EVT_HELP(wxID_ANY,                      OnHelp) 
 END_EVENT_TABLE()
@@ -138,7 +144,7 @@ ExternalToolsDialog::ExternalToolsDialog( wxWindow* parent, int id)
 
 	fgSizer2->Add( fgSizer8, 1, wxEXPAND, 5 );
 
-    /*
+    // Initial directory
 	fgSizer2->Add( new wxStaticText(this, wxID_ANY, wxT("Initial Directory:")), 0, wxALL, 5 );
 	
 	wxFlexGridSizer* fgSizer9;
@@ -149,11 +155,10 @@ ExternalToolsDialog::ExternalToolsDialog( wxWindow* parent, int id)
 	m_initialDirectoryTextBox = new wxTextCtrl( this, ID_InitialDirectoryTextBox);
 	fgSizer9->Add( m_initialDirectoryTextBox, 0, wxALL|wxEXPAND, 5 );
 	
-	m_button11 = new wxButton( this, wxID_ANY, wxT(">"), wxDefaultPosition, wxSize( 25,-1 ), 0 );
-	fgSizer9->Add( m_button11, 0, wxALL, 5 );
+	m_initialDirectoryBrowseButton = new wxButton( this, ID_InitialDirBrowseButton, wxT(">"), wxDefaultPosition, wxSize( 25,-1 ), 0 );
+	fgSizer9->Add( m_initialDirectoryBrowseButton, 0, wxALL, 5 );
 	
 	fgSizer2->Add( fgSizer9, 1, wxEXPAND, 5 );
-    */
 
     // Hook option.
     fgSizer2->Add( new wxStaticText( this, wxID_ANY, wxT("Auto-Execute On Event:")), 0, wxALL, 5 );
@@ -261,6 +266,15 @@ void ExternalToolsDialog::OnArgumentsTextBoxChanged(wxCommandEvent& event)
     if (tool != NULL)
     {
         tool->SetArguments(m_argumentsTextBox->GetValue());
+    }
+}
+
+void ExternalToolsDialog::OnInitialDirectoryTextBoxChanged(wxCommandEvent& event)
+{
+    ExternalTool* tool = GetSelectedTool();
+    if (tool != NULL)
+    {
+        tool->SetInitialDirectory(m_initialDirectoryTextBox->GetValue());
     }
 }
 
@@ -380,34 +394,40 @@ void ExternalToolsDialog::OnArgumentsBrowse(wxCommandEvent& event)
     point.x += m_argumentsBrowseButton->GetSize().x; 
 
     wxMenu menu;
-    menu.Append(ID_ItemPath,        _("Item &Path"));
-    menu.Append(ID_ItemDirectory,   _("&Item Directory"));
-    menu.Append(ID_ItemFileName,    _("Item &File Name"));
-    menu.Append(ID_ItemExtension,   _("Item E&xtension"));
+    menu.Append(ID_ArgumentsItemPath,        _("Item &Path"));
+    menu.Append(ID_ArgumentsItemDirectory,   _("&Item Directory"));
+    menu.Append(ID_ArgumentsItemFileName,    _("Item &File Name"));
+    menu.Append(ID_ArgumentsItemExtension,   _("Item E&xtension"));
     
     PopupMenu(&menu, point);
 
 }
 
-void ExternalToolsDialog::OnItemPath(wxCommandEvent& event)
+void ExternalToolsDialog::OnInitialDirectoryBrowse(wxCommandEvent& event)
 {
-    m_argumentsTextBox->WriteText("$(ItemPath)");
+
+    wxPoint point = m_initialDirectoryBrowseButton->GetPosition();
+    point.x += m_initialDirectoryBrowseButton->GetSize().x; 
+
+    wxMenu menu;
+    menu.Append(ID_InitialDirectoryItemPath,        _("Item &Path"));
+    menu.Append(ID_InitialDirectoryItemDirectory,   _("&Item Directory"));
+    menu.Append(ID_InitialDirectoryItemFileName,    _("Item &File Name"));
+    menu.Append(ID_InitialDirectoryItemExtension,   _("Item E&xtension"));
+    
+    PopupMenu(&menu, point);
+
 }
 
-void ExternalToolsDialog::OnItemDirectory(wxCommandEvent& event)
-{
-    m_argumentsTextBox->WriteText("$(ItemDir)");
-}
+void ExternalToolsDialog::OnArgumentsItemPath     (wxCommandEvent& event) { m_argumentsTextBox->WriteText("$(ItemPath)"    ); }
+void ExternalToolsDialog::OnArgumentsItemDirectory(wxCommandEvent& event) { m_argumentsTextBox->WriteText("$(ItemDir)"     ); }
+void ExternalToolsDialog::OnArgumentsItemFileName (wxCommandEvent& event) { m_argumentsTextBox->WriteText("$(ItemFileName)"); }
+void ExternalToolsDialog::OnArgumentsItemExtension(wxCommandEvent& event) { m_argumentsTextBox->WriteText("$(ItemExt)"     ); }
 
-void ExternalToolsDialog::OnItemFileName(wxCommandEvent& event)
-{
-    m_argumentsTextBox->WriteText("$(ItemFileName)");
-}
-
-void ExternalToolsDialog::OnItemExtension(wxCommandEvent& event)
-{
-    m_argumentsTextBox->WriteText("$(ItemExt)");
-}
+void ExternalToolsDialog::OnInitialDirectoryItemPath     (wxCommandEvent& event) { m_initialDirectoryTextBox->WriteText("$(ItemPath)"    ); }
+void ExternalToolsDialog::OnInitialDirectoryItemDirectory(wxCommandEvent& event) { m_initialDirectoryTextBox->WriteText("$(ItemDir)"     ); }
+void ExternalToolsDialog::OnInitialDirectoryItemFileName (wxCommandEvent& event) { m_initialDirectoryTextBox->WriteText("$(ItemFileName)"); }
+void ExternalToolsDialog::OnInitialDirectoryItemExtension(wxCommandEvent& event) { m_initialDirectoryTextBox->WriteText("$(ItemExt)"     ); }
 
 void ExternalToolsDialog::OnEventHook(wxCommandEvent& event)
 {
@@ -426,13 +446,9 @@ void ExternalToolsDialog::UpdateControlsForSelection(int selectedItem)
         const ExternalTool* tool = m_workingTools[selectedItem];
         
         m_titleTextBox->SetValue(tool->GetTitle());
-        m_titleTextBox->Enable(true);
-        
         m_commandTextBox->SetValue(tool->GetCommand());
-        m_commandTextBox->Enable(true);
-
         m_argumentsTextBox->SetValue(tool->GetArguments());
-        m_argumentsTextBox->Enable(true);
+        m_initialDirectoryTextBox->SetValue(tool->GetInitialDirectory());
 
         int selectionIndex = 0;
         int numEventTypes = sizeof(m_externalEvents) / sizeof(wxString);
@@ -445,29 +461,24 @@ void ExternalToolsDialog::UpdateControlsForSelection(int selectedItem)
             }
         }
         m_eventHookList->SetSelection(selectionIndex);
-        m_eventHookList->Enable(true);
-
     }
     else
     {
-    
         m_titleTextBox->Clear();
-        m_titleTextBox->Enable(false);
-        
         m_commandTextBox->Clear();
-        m_commandTextBox->Enable(false);
-
         m_argumentsTextBox->Clear();
-        m_argumentsTextBox->Enable(false);
-
+        m_initialDirectoryTextBox->Clear();
         m_eventHookList->SetSelection(0);
-        m_eventHookList->Enable(false);
-    
     }
-
-    m_commandBrowseButton->Enable(selectedItem != -1);
-    m_argumentsBrowseButton->Enable(selectedItem != -1);
-
+    
+    m_titleTextBox                ->Enable(selectedItem != -1);
+    m_commandTextBox              ->Enable(selectedItem != -1);
+    m_argumentsTextBox            ->Enable(selectedItem != -1);
+    m_initialDirectoryTextBox     ->Enable(selectedItem != -1);
+    m_eventHookList               ->Enable(selectedItem != -1);
+    m_commandBrowseButton         ->Enable(selectedItem != -1);
+    m_argumentsBrowseButton       ->Enable(selectedItem != -1);
+    m_initialDirectoryBrowseButton->Enable(selectedItem != -1);
 }
 
 ExternalTool* ExternalToolsDialog::GetSelectedTool()

--- a/src/Frontend/ExternalToolsDialog.h
+++ b/src/Frontend/ExternalToolsDialog.h
@@ -79,6 +79,11 @@ public:
     void OnArgumentsTextBoxChanged(wxCommandEvent& event);
 
     /**
+     * Called when the user changes the text in the initial directory text box.
+     */
+    void OnInitialDirectoryTextBoxChanged(wxCommandEvent& event);
+
+    /**
      * Called when the user clicks the Ok button.
      */
     void OnOk(wxCommandEvent& event);
@@ -119,24 +124,49 @@ public:
     void OnArgumentsBrowse(wxCommandEvent& event);
 
     /**
-     * Called when the user selects Item Path from the popup menu.
+     * Called when the user clicks the > button next to the initial directory box.
      */
-    void OnItemPath(wxCommandEvent& event);
+    void OnInitialDirectoryBrowse(wxCommandEvent& event);
 
     /**
-     * Called when the user selects Item Directory from the popup menu.
+     * Called when the user selects Item Path from the popup menu for arguments.
      */
-    void OnItemDirectory(wxCommandEvent& event);
+    void OnArgumentsItemPath(wxCommandEvent& event);
 
     /**
-     * Called when the user selects Item File Name from the popup menu.
+     * Called when the user selects Item Directory from the popup menu for arguments.
      */
-    void OnItemFileName(wxCommandEvent& event);
+    void OnArgumentsItemDirectory(wxCommandEvent& event);
 
     /**
-     * Called when the user selects Item Extension from the popup menu.
+     * Called when the user selects Item File Name from the popup menu for arguments.
      */
-    void OnItemExtension(wxCommandEvent& event);
+    void OnArgumentsItemFileName(wxCommandEvent& event);
+
+    /**
+     * Called when the user selects Item Extension from the popup menu for arguments.
+     */
+    void OnArgumentsItemExtension(wxCommandEvent& event);
+
+    /**
+     * Called when the user selects Item Path from the popup menu for the initial directory.
+     */
+    void OnInitialDirectoryItemPath(wxCommandEvent& event);
+
+    /**
+     * Called when the user selects Item Directory from the popup menu for the initial directory.
+     */
+    void OnInitialDirectoryItemDirectory(wxCommandEvent& event);
+
+    /**
+     * Called when the user selects Item File Name from the popup menu for the initial directory.
+     */
+    void OnInitialDirectoryItemFileName(wxCommandEvent& event);
+
+    /**
+     * Called when the user selects Item Extension from the popup menu for the initial directory.
+     */
+    void OnInitialDirectoryItemExtension(wxCommandEvent& event);
 
     /**
      * Called when the user selects an event to hook into from the list box.
@@ -178,6 +208,7 @@ private:
         ID_TitleTextBox,
         ID_CommandTextBox,
         ID_ArgumentsTextBox,
+        ID_InitialDirectoryTextBox,
         ID_ApplyButton,
         ID_AddButton,
         ID_DeleteButton,
@@ -185,10 +216,15 @@ private:
         ID_MoveDownButton,
         ID_CommandBrowseButton,
         ID_ArgumentsBrowseButton,
-        ID_ItemPath,
-        ID_ItemDirectory,
-        ID_ItemFileName,
-        ID_ItemExtension,
+        ID_InitialDirBrowseButton,
+        ID_ArgumentsItemPath,
+        ID_ArgumentsItemDirectory,
+        ID_ArgumentsItemFileName,
+        ID_ArgumentsItemExtension,
+        ID_InitialDirectoryItemPath,
+        ID_InitialDirectoryItemDirectory,
+        ID_InitialDirectoryItemFileName,
+        ID_InitialDirectoryItemExtension,
         ID_EventHook,
     };
 
@@ -204,7 +240,7 @@ private:
 	wxButton*           m_argumentsBrowseButton;
     wxChoice*           m_eventHookList;
 	wxTextCtrl*         m_initialDirectoryTextBox;
-	wxButton*           m_button11;
+	wxButton*           m_initialDirectoryBrowseButton;
 	wxButton*           m_button12;
 	wxButton*           m_button13;
     wxButton*           m_button14;

--- a/src/Frontend/KeyBinderDialog.cpp
+++ b/src/Frontend/KeyBinderDialog.cpp
@@ -155,7 +155,7 @@ void KeyBinderDialog::Initialize()
         {
             // We haven't encountered this group yet, so create a new node for it.
             groupNode = m_commandTreeCtrl->AppendItem(root, m_commands[i]->group);
-            groups.insert(std::make_pair(m_commands[i]->group, groupNode));
+            groups.insert(std::make_pair(m_commands[i]->group.ToAscii(), groupNode));
         }
         else
         {

--- a/src/Frontend/MainFrame.cpp
+++ b/src/Frontend/MainFrame.cpp
@@ -3925,11 +3925,15 @@ void MainFrame::LoadExternalTool(wxXmlNode* node)
     wxString arguments;
     node->GetPropVal("arguments", &arguments);
 
+    wxString initialDirectory;
+    node->GetPropVal("initialdirectory", &initialDirectory);
+
     ExternalTool* tool = new ExternalTool;
 
     tool->SetTitle(title);
     tool->SetCommand(command);
     tool->SetArguments(arguments);
+    tool->SetInitialDirectory(initialDirectory);
 
     m_tools.push_back(tool);
 
@@ -4058,6 +4062,7 @@ wxXmlNode* MainFrame::SaveExternalTool(const ExternalTool* tool) const
     node->AddProperty("title", tool->GetTitle());
     node->AddProperty("command", tool->GetCommand());
     node->AddProperty("arguments", tool->GetArguments());
+    node->AddProperty("initialdirectory", tool->GetInitialDirectory());
 
     return node;
 

--- a/src/Frontend/MainFrame.cpp
+++ b/src/Frontend/MainFrame.cpp
@@ -3165,7 +3165,7 @@ void MainFrame::OnIdle(wxIdleEvent& event)
 
         wxProcess* process = m_runningProcesses[i];
         
-        if (CopyProcessOutputToWindow(process))
+        if (m_processOutputSink.Pump(*m_output, *process))
         {
             // We have more input to process, so get another idle.
             event.RequestMore();
@@ -3204,9 +3204,7 @@ void MainFrame::OnProcessTerminate(wxProcessEvent& event)
         {
 
             // Grab any remaning output from this process.
-            while (CopyProcessOutputToWindow(process))
-            {
-            }
+            m_processOutputSink.Dump(*m_output, *process);
 
             // Ring the bell to alert the user.
             wxBell();
@@ -3722,29 +3720,6 @@ void MainFrame::FindText(OpenFile* file, const wxString& text, int flags)
 
 }
 
-bool MainFrame::CopyProcessOutputToWindow(wxProcess* process)
-{
-    
-    bool hasInput = false;
-
-    if (process->IsInputAvailable())
-    {
-        wxTextInputStream stream(*process->GetInputStream());
-        m_output->OutputMessage(stream.ReadLine());
-        hasInput = true;
-    }
-
-    if (process->IsErrorAvailable() )
-    {
-        wxTextInputStream stream(*process->GetErrorStream());
-        m_output->OutputMessage(stream.ReadLine());
-        hasInput = true;
-    }
-
-    return hasInput;
-
-}
-    
 void MainFrame::SubstituteVariableArguments(wxString& text) const
 {
     

--- a/src/Frontend/MainFrame.h
+++ b/src/Frontend/MainFrame.h
@@ -46,6 +46,7 @@ along with Decoda.  If not, see <http://www.gnu.org/licenses/>.
 #include "StringHistory.h"
 #include "AutoCompleteManager.h"
 #include "DebugFrontend.h"
+#include "ProcessOutputSink.h"
 
 #include <vector>
 #include <string>
@@ -990,12 +991,6 @@ private:
     void RemoveRunningProcess(wxProcess* process);
 
     /**
-     * Copies the text from the process output stream to the output window. Returns
-     * false if no data was copied.
-     */
-    bool CopyProcessOutputToWindow(wxProcess* process);
-
-    /**
      * Updates the tools menu items based on the current external tools.
      */
     void UpdateToolsMenu();
@@ -1533,6 +1528,7 @@ private:
     bool                            m_startUpMaximized;
 
     AutoCompleteManager             m_autoCompleteManager;
+    ProcessOutputSink               m_processOutputSink;
 
     std::vector<int>                m_tabOrder;
     int                             m_tabOrderIndex;

--- a/src/Frontend/ProcessOutputSink.cpp
+++ b/src/Frontend/ProcessOutputSink.cpp
@@ -1,0 +1,111 @@
+
+#include <vector>
+#include <wx/process.h>
+
+#include "ProcessOutputSink.h"
+#include "OutputWindow.h"
+
+
+#ifndef LENGTH_OF
+    #define LENGTH_OF(a) (sizeof(a) / sizeof(*a))
+#endif
+
+struct ProcessOutputSink::Sink
+{
+    struct Buffer {
+        Buffer() : _head(NULL), _tail(NULL) { }
+        wxChar* _head; wxChar* _tail;
+        wxChar _data[ProcessOutputSink::kPumpBatchSize];
+    } _message, _error;
+};
+
+namespace
+{
+    void DumpSink(OutputWindow& output, ProcessOutputSink::Sink::Buffer& buffer, bool requireEOL)
+    {
+        bool    hasLine = false;
+        wxChar* offset  = buffer._head;
+        while (offset < buffer._tail)
+        {
+            wxChar* eol    = wxStrchr(offset, wxT('\n'));
+            size_t  length = size_t(buffer._tail - offset);
+            if (eol)
+            {
+                hasLine = true;
+                length  = size_t(eol - offset);
+            }
+            else if (hasLine && requireEOL)
+                break;
+            
+            if (length > 0)
+            {
+                wxString s(offset, length);
+                output.OutputMessage(s);
+            }
+            
+            offset += length + 1;
+        }
+        
+        buffer._head = std::min(offset, buffer._tail);
+    }
+    
+    void PumpStream(OutputWindow& output, wxInputStream& stream, ProcessOutputSink::Sink::Buffer& buffer)
+    {
+        if (!stream.CanRead()) return;
+        
+        // Move any data remaining to head of buffer. Nop if remainder==0.
+        assert(buffer._head <= buffer._tail);
+        size_t remainder = size_t(buffer._tail - buffer._head);
+        memmove(buffer._data, buffer._head, remainder * sizeof(wxChar));
+        
+        // Fill in rest of buffer
+        size_t size = sizeof(buffer._data) - remainder * sizeof(wxChar);
+        stream.Read(buffer._data + remainder, size);
+        buffer._head = buffer._data;
+        buffer._tail = buffer._data + remainder + stream.LastRead();
+        
+        DumpSink(output, buffer, true);
+    }
+}
+
+bool ProcessOutputSink::Pump(OutputWindow& output, wxProcess& process)
+{
+    bool  hasInput = false;
+    Sink* sink     = SinkGet(process);
+    
+    if (process.IsInputAvailable())
+    {
+        hasInput = true;
+        PumpStream(output, *process.GetInputStream(), sink->_message);
+    }
+    
+    if (process.IsErrorAvailable())
+    {
+        hasInput = true;
+        PumpStream(output, *process.GetErrorStream(), sink->_error);
+    }
+    
+    return hasInput;
+}
+
+void ProcessOutputSink::Dump(OutputWindow& output, wxProcess& process)
+{
+    while (Pump(output, process));
+    
+    Sink* sink = SinkGet(process);
+    DumpSink(output, sink->_message, false);
+    DumpSink(output, sink->_error  , false);
+    
+    _sinks.erase(_sinks.find(&process));
+    delete sink;
+}
+
+ProcessOutputSink::Sink* ProcessOutputSink::SinkGet(wxProcess& process)
+{
+    std::map<wxProcess*, Sink*>::iterator iter = _sinks.find(&process);
+    if (iter != _sinks.end()) return iter->second;
+    
+    Sink* p_sink = new Sink;
+    _sinks.insert(std::make_pair(&process, p_sink));
+    return p_sink;
+}

--- a/src/Frontend/ProcessOutputSink.h
+++ b/src/Frontend/ProcessOutputSink.h
@@ -1,0 +1,55 @@
+/*
+
+Decoda
+Copyright (C) 2007-2013 Unknown Worlds Entertainment, Inc. 
+
+This file is part of Decoda.
+
+Decoda is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Decoda is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Decoda.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef PROCESS_OUTPUT_SINK_H
+#define PROCESS_OUTPUT_SINK_H
+
+#include <map>
+
+class OutputWindow;
+class wxProcess;
+
+class ProcessOutputSink
+{
+    public:
+        /// Amount of bytes to attempt to read from error/output per pump.
+        /// This is required since we cannot assume the process will ever
+        /// emit an EOL, potentially deadlocking us if it emits faster than
+        /// we may read. This also allows us to perform some minimal amount of
+        /// batch/grouping to prevent unnecessary interweaving of stdout/stderr.
+        /// 
+        /// If we've > 0 EOL in the batch, then we save the left overs (if any)
+        /// for the next pump and dump it then. This makes the output a bit
+        /// prettier if we hit the batch-limit mid-line.
+        static const size_t kPumpBatchSize = 2048;
+        struct Sink;
+        
+        bool Pump(OutputWindow& output, wxProcess& process);
+        void Dump(OutputWindow& output, wxProcess& process);
+        
+    private:
+        Sink* SinkGet(wxProcess& process);
+        std::map<wxProcess*, Sink*> _sinks;
+};
+
+#endif
+


### PR DESCRIPTION
Rogue/runaway tool processes can no longer cause Decoda to deadlock if their output does not contain an EOL char.
Stderr/stdout output no longer interweaves quite as much. (Makes debugging much easier..)
External tools now have an Initial Working Directory option.

(Both are rather critical if you have a Run Script external tool...)
