### PR TITLE
Fix call hook handling

### DIFF
--- a/src/LuaInject/DebugBackend.cpp
+++ b/src/LuaInject/DebugBackend.cpp
@@ -808,7 +808,7 @@ void DebugBackend::HookCallback(unsigned long api, lua_State* L, lua_Debug* ar)
         int scriptIndex = GetScriptIndex(arsource);
 
         if (scriptIndex == -1)
-        {            
+        {
             // This isn't a script we've seen before, so tell the debugger about it.
             scriptIndex = RegisterScript( api, L, ar);
         }
@@ -883,7 +883,7 @@ void DebugBackend::HookCallback(unsigned long api, lua_State* L, lua_Debug* ar)
                     --vm->callCount;
                 }
             }
-            else if (arevent == LUA_HOOKCALL)
+            else if( GetIsHookEventCall( api, arevent)) // only LUA_HOOKCALL for Lua 5.1, can also be LUA_HOOKTAILCALL for newer versions
             {
                 if (m_mode == Mode_StepOver)
                 {
@@ -914,7 +914,7 @@ void DebugBackend::UpdateHookMode(unsigned long api, lua_State* L, lua_Debug* ho
     lua_getinfo_dll(api, L, "S", hookEvent);
     int linedefined = GetLineDefined(api, hookEvent);
 
-    if (arevent == LUA_HOOKCALL && linedefined != -1)
+    if( GetIsHookEventCall( api, arevent) && linedefined != -1)
     {
         vm->lastFunctions = GetSource(api, hookEvent);
 
@@ -925,7 +925,7 @@ void DebugBackend::UpdateHookMode(unsigned long api, lua_State* L, lua_Debug* ho
             RegisterScript(api, L, hookEvent);
             scriptIndex = GetScriptIndex(vm->lastFunctions.c_str());
         }
-        
+
         Script* script = scriptIndex != -1 ? m_scripts[scriptIndex] : NULL;
 
         int lastlinedefined = GetLastLineDefined( api, hookEvent);

--- a/src/LuaInject/LuaDll.cpp
+++ b/src/LuaInject/LuaDll.cpp
@@ -3220,14 +3220,14 @@ bool LoadLuaFunctions(const stdext::hash_map<std::string, DWORD64>& symbols, HAN
             luaInterface.registryIndex  = -1001000;
             // starting with Lua 5.2, there is no longer a LUA_GLOBALSINDEX pseudo-index. Instead the global table is stored in the registry at LUA_RIDX_GLOBALS
             luaInterface.globalsIndex   = 2;
-            luaInterface.hookTailRet = 4; // LUA_HOOKTAILRET
+            luaInterface.hookTailCall = LUA_HOOKTAILCALL; // Lua5.2 has LUA_HOOKTAILCALL, but no LUA_HOOKTAILRET
         }
         else if ( symbols.find("lua_gettop") != symbols.end()) // should be ok for any version
         {
             luaInterface.version        = 510;
             luaInterface.registryIndex  = -10000;
             luaInterface.globalsIndex   = -10002;
-            luaInterface.hookTailCall = 4; // LUA_HOOKTAILCALL
+            luaInterface.hookTailRet = LUA_HOOKTAILRET; // // Lua5.1 has LUA_HOOKTAILRET, but no LUA_HOOKTAILCALL
         }
         else // if we get here, this means the module isn't related to Lua at all
         {


### PR DESCRIPTION
This fixes some situations where breakpoints could be ignored when set in a function invoked by tail call.
